### PR TITLE
Fixing typo in `stackoverflow`

### DIFF
--- a/_posts/2020-11-14-how-to-make-your-open-source-project-successful.md
+++ b/_posts/2020-11-14-how-to-make-your-open-source-project-successful.md
@@ -108,7 +108,7 @@ To learn how to manage an open-source project and how to contribute to another o
 - {:.fragment} Participate in the issue/feature request/pr discussion
 - {:.fragment} Donating
 - {:.fragment} Write your article/tutorials/docs about this project
-- {:.fragment} Answer questions in issues/starkoverflow...
+- {:.fragment} Answer questions in issues/stackoverflow...
 
 </section>
 


### PR DESCRIPTION
It was previously `starkoverflow`, not sure if that was an intentional Tony Stark reference, but I thought it was a typo :)